### PR TITLE
Fix for proper boolean value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,8 +62,8 @@ class puppetci {
   }
 
   class {'jenkins':
-    lts  => 0,
-    repo => 1,
+    lts  => true,
+    repo => true,
   }
 
   class {'puppetci::plugins':


### PR DESCRIPTION
Changed lts & repo flag to be valid boolean values as expected by the rtyler/jenkins and stdlib modules.
